### PR TITLE
Use hexpose iotas and fix namespacing issue

### DIFF
--- a/Patterns/convert.lua
+++ b/Patterns/convert.lua
@@ -4,16 +4,22 @@ local Identifier = require("net.minecraft.util.Identifier")
 local Registries = require("net.minecraft.registry.Registries")
 
 local StringIota = require("ram.talia.moreiotas.api.casting.iota.StringIota")
-local IdentifierIota = require("miyucomics.hexical.casting.iotas.IdentifierIota")
+local IdentifierIota = require("miyucomics.hexpose.iotas.IdentifierIota")
 local ItemTypeIota = require("ram.talia.moreiotas.api.casting.iota.ItemTypeIota")
 local NullIota = require("at.petrak.hexcasting.api.casting.iota.NullIota")
 
 local iotaConversions = {
-    ["miyucomics.hexical.casting.iotas.IdentifierIota"] = function(iota)
+    ["miyucomics.hexpose.iotas.IdentifierIota"] = function(iota)
         return ItemTypeIota(Registries.ITEM:get(iota:getIdentifier()))
     end,
     ["ram.talia.moreiotas.api.casting.iota.ItemTypeIota"] = function(iota)
-        return IdentifierIota(Identifier(iota:getItem():toString()))
+		local tag = iota:serialize()
+		print("changed")
+		local id = tag:getString("item")
+		if #id == 0 then
+			id = tag:getString("block")
+		end
+        return IdentifierIota(Identifier(id))
     end,
 }
 


### PR DESCRIPTION
get updated idiot /j

Switches over to the hexpose identifier iotas, following the transfer of them from hexical, along with fixing an existing issue where modded item types were given the `minecraft` namespace.

My solution does serialize hexal type iotas, which could be a performance issue. There is a possible solution with indexing the registries as seen [here](https://github.com/Talia-12/MoreIotas/blob/3f09b88679ac90ccd67c979b826c2eb24a4ae90f/Common/src/main/java/ram/talia/moreiotas/api/casting/iota/ItemTypeIota.java#L83).